### PR TITLE
Add recurring appointments to calendar events

### DIFF
--- a/index.html
+++ b/index.html
@@ -1216,6 +1216,13 @@
         icsContent += `DTSTART;VALUE=DATE:${dtStart}\r\n`;
         icsContent += `SUMMARY:${event.name}\r\n`;
         icsContent += `DESCRIPTION:${event.description}\r\n`;
+
+        // Add recurrence rule based on interval (in months)
+        // For future checkups, don't add RRULE since they're one-time notifications
+        if (!event.future && event.interval) {
+          icsContent += `RRULE:FREQ=MONTHLY;INTERVAL=${event.interval}\r\n`;
+        }
+
         icsContent += 'STATUS:CONFIRMED\r\n';
         icsContent += 'TRANSP:TRANSPARENT\r\n';
         icsContent += 'BEGIN:VALARM\r\n';


### PR DESCRIPTION
Implements recurring appointments feature requested in issue #8.

## Changes
- Added RRULE (Recurrence Rule) to ICS file generation
- Current checkups now repeat automatically based on their interval
- Future checkups remain single events (one-time notifications)
- Follows RFC 5545 standard for iCalendar recurring events

Fixes #8

Generated with [Claude Code](https://claude.ai/code)